### PR TITLE
Update path filters which are not lowercase anymore

### DIFF
--- a/s2coastalbot/sentinel2.py
+++ b/s2coastalbot/sentinel2.py
@@ -66,7 +66,7 @@ def read_nodata_from_l2a_prod(product_series, output_folder, products_api, logge
     """
 
     # download L2A product metadata file
-    nodefilter = make_path_filter("*mtd_msil2a.xml")
+    nodefilter = make_path_filter("*MTD_MSIL2A.xml")
     product_info = sentinelsat_retry_download(
         products_api,
         product_series["uuid"],
@@ -248,7 +248,7 @@ def download_tci_image(
         sys.exit(128)
 
     # download only TCI band
-    nodefilter = make_path_filter("*_tci_10m.jp2")
+    nodefilter = make_path_filter("*_TCI_10m.jp2")
     product_info = sentinelsat_retry_download(
         products_api, product_row["uuid"], output_folder, nodefilter, logger
     )


### PR DESCRIPTION
Path filtering function, available in sentinelsat in order to download specific files within a product bundle, used to convert string to lowercase before pattern matching.

Path filters are not converted to lowercase anymore since [this PR in sentinelsat](https://github.com/sentinelsat/sentinelsat/pull/541).

This updates path filtering in s2coastalbot to comply with the new behavior.