### PR TITLE
Add missing directory level in cleaning

### DIFF
--- a/s2coastalbot/main.py
+++ b/s2coastalbot/main.py
@@ -70,8 +70,8 @@ class S2CoastalBot:
         logger.info("Authenticating against twitter API")
         auth = tweepy.OAuthHandler(consumer_key, consumer_secret)
         auth.set_access_token(access_token, access_token_secret)
-        apiv1 = tweepy.API(auth) # API v1.1 required to upload media
-        apiv2 = tweepy.Client( # API v2 required to post tweets
+        apiv1 = tweepy.API(auth)  # API v1.1 required to upload media
+        apiv2 = tweepy.Client(  # API v2 required to post tweets
             consumer_key=consumer_key,
             consumer_secret=consumer_secret,
             access_token=access_token,
@@ -93,11 +93,12 @@ class S2CoastalBot:
         if cleaning:
             logger.info("Cleaning data")
             product_path = os.path.dirname(
-                os.path.dirname(os.path.dirname(os.path.dirname(postprocessed_file_path)))
+                os.path.dirname(
+                    os.path.dirname(os.path.dirname(os.path.dirname(postprocessed_file_path)))
+                )
             )
             shutil.rmtree(product_path)
 
 
 if __name__ == "__main__":
-
     s2coastalbot = S2CoastalBot()


### PR DESCRIPTION
A upper directory level was missing in the cleaning command. Therefore the GRANULE folder within the product's folder was cleaned, and the rest of the product folder (mainly metadata) was not cleaned. This fixes the issue and the whole product folder whould be cleaned from now on.