### PR TITLE
Add test to check latest status change

### DIFF
--- a/.github/workflows/latest_status.yml
+++ b/.github/workflows/latest_status.yml
@@ -1,0 +1,14 @@
+name: Check latest status date
+on:
+  push:
+  schedule:
+    - cron: "26 10 * * 4"  # Set to run every Thursdays
+jobs:
+  latest-status:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Run tests
+        run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 config/config.ini
 config/*.secret
 data/*
-tests/*
 logs/*
 tmp/*
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,3 +13,5 @@ fiona
 pyproj
 icecream
 Mastodon.py
+pytz
+pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ rasterio
 fiona
 pyproj
 Mastodon.py
+pytz
+pytest

--- a/tests/test_latest_status.py
+++ b/tests/test_latest_status.py
@@ -1,0 +1,25 @@
+"""Check if the bot has updated its status in the last 24 hours.
+
+This is not actually testing the code. It's a way to alert if something is wrong with the bot.
+"""
+
+# standard library
+import datetime
+
+# third party
+import pytz
+from mastodon import Mastodon
+
+
+def test_latest_status():
+    """Check if the bot has updated its status in the last 24 hours."""
+
+    # lookup latest status
+    mastodon = Mastodon(api_base_url="https://mastodon.social")
+    account = mastodon.account_lookup("s2coastalbot")
+    status = mastodon.account_statuses(id=account.id, only_media=True, limit=1)[0]
+
+    # check latest status date
+    yesterday = datetime.datetime.now() - datetime.timedelta(days=1)
+    yesterday = pytz.UTC.localize(yesterday)
+    assert status.created_at > yesterday


### PR DESCRIPTION
Use a scheduled GitHub Actions workflow to check if the bot has updated its status in the last 24 hours.

This is not actually testing the code. It's a way to alert if something is wrong with the bot.