### PR TITLE
Improve requests to OSM's Nominatim service

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 
 Inspired from [Sentinel2Bot](https://twitter.com/Sentinel2Bot) and [LandsatBot](https://twitter.com/LandsatBot).
 
-Described in more details on [thibautvoirand.com/s2coastalbot](https://thibautvoirand.com/s2coastalbot/).
+Described in more details on [thibautvoirand.com/s2coastalbot](https://thibautvoirand.com/s2coastalbot).
 
 ### Installation
 
@@ -21,3 +21,7 @@ For example using pip:
 ### Contribute
 
 Please feel free to contribute by opening issues or pull-requests!
+
+### Credits
+
+Image locations descriptions are obtained from [OpenStreetMap](https://www.openstreetmap.org/copyright).

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,6 +7,7 @@ fiona
 pyproj
 Mastodon.py
 pytz
+backoff
 pytest
 flake8
 black

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ fiona
 pyproj
 Mastodon.py
 pytz
+backoff


### PR DESCRIPTION
Improve requests to OSM's Nominatim service.

This allows to comply with the service [usage policy](https://operations.osmfoundation.org/policies/nominatim/), and avoid blockages.