### PR TITLE
Change method for image and subset selection

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,8 @@
 tweepy
 sentinelsat @ git+https://github.com/tvoirand/sentinelsat@dev_thib
-pandas
 shapely
 rasterio
-fiona
+geopandas
 pyproj
 Mastodon.py
 pytz

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
 tweepy
 sentinelsat @ git+https://github.com/tvoirand/sentinelsat@dev_thib
-pandas
 shapely
 rasterio
-fiona
+geopandas
 pyproj
 Mastodon.py
 pytz

--- a/s2coastalbot/main.py
+++ b/s2coastalbot/main.py
@@ -50,21 +50,20 @@ def s2coastalbot_main(config):
         tci_file_path, date = download_tci_image(config)
 
         try:
-            # postprocess image to fit twitter or mastodon contraints
+            # postprocess image to get a smaller subset
             logger.info("Postprocessing image")
             aoi_file_postprocessing = Path(config.get("misc", "aoi_file_postprocessing"))
             postprocessed_file_path, subset_center_coords = postprocess_tci_image(
                 tci_file_path, aoi_file_postprocessing
             )
+            if postprocessed_file_path is None:
+                continue  # no subset found within this image, try downloading another image
             location_name = get_location_name(subset_center_coords)
             text = "{} ({}) {}".format(
                 location_name,
                 format_lon_lat(subset_center_coords),
                 date.strftime("%Y %b %d"),
             )
-        except StopIteration:
-            if cleaning:
-                clean_data_based_on_tci_file(tci_file_path)
         except Exception as error_msg:
             logger.error(f"Error postprocessing image: {error_msg}")
             if cleaning:

--- a/s2coastalbot/main.py
+++ b/s2coastalbot/main.py
@@ -6,11 +6,13 @@ Bot that posts newly acquired Sentinel-2 images of coastal areas, on Twitter and
 # standard library
 import argparse
 import configparser
+import datetime
 import logging
 import shutil
 from pathlib import Path
 
 # third party
+import pandas as pd
 import tweepy
 from mastodon import Mastodon
 
@@ -144,6 +146,18 @@ def s2coastalbot_main(config):
         if cleaning:
             clean_data_based_on_tci_file(tci_file_path)
         return
+
+    # update list of posted images
+    posted_images_file = project_path / "data" / "posted_images.csv"
+    if not posted_images_file.exists():  # initiate file if necessary
+        posted_images = pd.DataFrame(columns=["date", "product"])
+    else:
+        posted_images = pd.read_csv(posted_images_file)
+    posted_images.loc[len(posted_images)] = [
+        datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S"),
+        tci_file_path.parents[4].stem,
+    ]
+    posted_images.to_csv(posted_images_file, index=False)
 
     # clean data if necessary
     if cleaning:

--- a/s2coastalbot/main.py
+++ b/s2coastalbot/main.py
@@ -52,20 +52,27 @@ def s2coastalbot_main(config):
         tci_file_path, date = download_tci_image(config)
 
         try:
+
             # postprocess image to get a smaller subset
             logger.info("Postprocessing image")
             aoi_file_postprocessing = Path(config.get("misc", "aoi_file_postprocessing"))
             postprocessed_file_path, subset_center_coords = postprocess_tci_image(
                 tci_file_path, aoi_file_postprocessing
             )
+
             if postprocessed_file_path is None:
-                continue  # no subset found within this image, try downloading another image
+                # no subset found within this image, try downloading another image
+                if cleaning:
+                    clean_data_based_on_tci_file(tci_file_path)
+                continue
+
             location_name = get_location_name(subset_center_coords)
             text = "{} ({}) {}".format(
                 location_name,
                 format_lon_lat(subset_center_coords),
                 date.strftime("%Y %b %d"),
             )
+
         except Exception as error_msg:
             logger.error(f"Error postprocessing image: {error_msg}")
             if cleaning:

--- a/s2coastalbot/postprocessing.py
+++ b/s2coastalbot/postprocessing.py
@@ -12,6 +12,8 @@ import numpy as np
 import pyproj
 import rasterio
 from rasterio.windows import Window
+from shapely.geometry import LineString
+from shapely.geometry import MultiLineString
 from shapely.geometry import Point
 from shapely.geometry import Polygon
 
@@ -87,7 +89,13 @@ def postprocess_tci_image(input_file, aoi_file):
         # locate image subset center among intersections with coastline
         logger.info("Locating subset center among intersections with coastline")
         gdf = gpd.read_file(aoi_file)
-        coastline_subsets = footprint.intersection(gdf["geometry"])
+        intersection = footprint.intersection(gdf["geometry"])
+        coastline_subsets = []
+        for geom in intersection:
+            if isinstance(geom, LineString):
+                coastline_subsets.append(geom)
+            elif isinstance(geom, MultiLineString):
+                coastline_subsets.extend(geom.geoms)
         coastline_subsets = [line for line in coastline_subsets if not line.is_empty]
 
         # raise error if there are no intersection with coastline

--- a/s2coastalbot/postprocessing.py
+++ b/s2coastalbot/postprocessing.py
@@ -14,6 +14,7 @@ import rasterio
 from rasterio.windows import Window
 from shapely.geometry import LineString
 from shapely.geometry import MultiLineString
+from shapely.geometry import Point
 from shapely.geometry import Polygon
 
 # current project
@@ -93,8 +94,8 @@ def postprocess_tci_image(input_file, aoi_file, logger=None):
         footprint = [(lon, lat) for (lat, lon) in utm_to_latlon.itransform(footprint)]
         footprint = Polygon(footprint)
 
-        # locate image subset center among intersections with coastline
-        logger.info("Locating subset center among intersections with coastline")
+        # locate intersections with coastline
+        logger.info("Locating intersections with coastline")
         coastline_subsets = []
         with fiona.open(aoi_file, "r") as infile:
             for feat in infile:
@@ -102,50 +103,73 @@ def postprocess_tci_image(input_file, aoi_file, logger=None):
                 if line.intersects(footprint):
                     intersection = line.intersection(footprint)
                     if type(intersection) == LineString:
-                        coastline_subsets.append(line.intersection(footprint))
+                        coastline_subsets.append(intersection)
                     elif type(intersection) == MultiLineString:
-                        for linestring in intersection:
+                        for linestring in intersection.geoms:
                             coastline_subsets.append(linestring)
 
         # raise error if there are no intersection with coastline
         if coastline_subsets == []:
             raise Exception("No intersection with coastline found")
 
-        center_coords = random.choice(random.choice(coastline_subsets).coords)
-        logger.info(
-            "Subset center (lon, lat): {:.4f} - {:.4f}".format(center_coords[0], center_coords[1])
-        )
+        # list up to a hundred of potential subset centers randomly picked along coastline
+        coastline_points = [
+            Point(coords) for line in coastline_subsets for coords in line.coords[:]
+        ]
+        random.shuffle(coastline_points)
+        coastline_points = coastline_points[:100]
 
-        # find subset center pixel
-        latlon_to_utm = pyproj.Transformer.from_crs(4326, in_dataset.crs.to_epsg())
-        center_coords_utm = latlon_to_utm.transform(center_coords[1], center_coords[0])
-        center_pixel = rasterio.transform.rowcol(
-            in_dataset.transform, center_coords_utm[0], center_coords_utm[1]
-        )
+        # loop through potential subset centers, and check if subset contains nodata pixels
+        logger.info("Checking for nodata around a set of points along coastline")
+        for subset_center in coastline_points:
 
-        # find subset window
-        logger.info("Finding corresponding subset window")
-        row_start, row_stop, col_start, col_stop = get_window(
-            center_pixel, SUBSET_SIZE, SUBSET_SIZE, INPUT_MAX_SIZE, INPUT_MAX_SIZE
-        )
-        window = Window.from_slices((row_start, row_stop), (col_start, col_stop))
+            # find subset center pixel
+            logger.debug("Finding subset center pixel")
+            latlon_to_utm = pyproj.Transformer.from_crs(4326, in_dataset.crs.to_epsg())
+            center_coords_utm = latlon_to_utm.transform(subset_center.y, subset_center.x)
+            center_pixel = rasterio.transform.rowcol(
+                in_dataset.transform, center_coords_utm[0], center_coords_utm[1]
+            )
 
-        # read subset of TCI image
-        array = in_dataset.read(window=window)
+            # find subset window
+            logger.debug("Finding corresponding subset window")
+            row_start, row_stop, col_start, col_stop = get_window(
+                center_pixel, SUBSET_SIZE, SUBSET_SIZE, INPUT_MAX_SIZE, INPUT_MAX_SIZE
+            )
+            window = Window.from_slices((row_start, row_stop), (col_start, col_stop))
 
-        # write subset to output file
-        logger.info("Writing subset output file")
-        with rasterio.open(
-            output_file,
-            "w",
-            driver="PNG",
-            count=in_dataset.count,
-            height=SUBSET_SIZE,
-            width=SUBSET_SIZE,
-            dtype=np.uint8,
-            transform=in_dataset.window_transform(window),
-            crs=in_dataset.crs,
-        ) as out_dataset:
-            out_dataset.write(array)
+            # read subset of TCI image
+            logger.debug("Reading subset of TCI image")
+            array = in_dataset.read(window=window)
 
-    return output_file, center_coords
+            # check ratio of nodata pixels, if it's inferior to 5%, select this subset and continue
+            logger.debug("Checking nodata pixels ratio")
+            non_zero_array = np.count_nonzero(array, axis=0)  # array of non-zero count along bands
+            non_zero_count = np.count_nonzero(non_zero_array)  # amount of non-zero pixles in array
+            nodata_ratio = 1 - non_zero_count / array.shape[1] / array.shape[2]
+            if nodata_ratio < 0.05:
+                logger.info(
+                    "Selected subset center (lon, lat): {:.4f} - {:.4f}".format(
+                        subset_center.x, subset_center.y
+                    )
+                )
+
+                # write subset to output file
+                logger.info("Writing subset output file")
+                with rasterio.open(
+                    output_file,
+                    "w",
+                    driver="PNG",
+                    count=in_dataset.count,
+                    height=SUBSET_SIZE,
+                    width=SUBSET_SIZE,
+                    dtype=np.uint8,
+                    transform=in_dataset.window_transform(window),
+                    crs=in_dataset.crs,
+                ) as out_dataset:
+                    out_dataset.write(array)
+
+                return output_file, (subset_center.x, subset_center.y)
+
+        logger.info("Couldn't find subset with <5% nodata in this image")
+        raise StopIteration(f"Couldn't find subset with <5% nodata in {input_file.stem}")

--- a/s2coastalbot/postprocessing.py
+++ b/s2coastalbot/postprocessing.py
@@ -154,4 +154,4 @@ def postprocess_tci_image(input_file, aoi_file):
                 return output_file, (subset_center.x, subset_center.y)
 
         logger.info("Couldn't find subset with <5% nodata in this image")
-        raise StopIteration(f"Couldn't find subset with <5% nodata in {input_file.stem}")
+        return None, None

--- a/s2coastalbot/sentinel2.py
+++ b/s2coastalbot/sentinel2.py
@@ -5,8 +5,6 @@ Sentinel-2 data handling module for s2coastalbot.
 # standard library
 import datetime
 import random
-import shutil
-import xml.etree.ElementTree as ET
 from pathlib import Path
 from time import sleep
 
@@ -20,48 +18,6 @@ from shapely.geometry import MultiPoint
 
 # current project
 from s2coastalbot.custom_logger import get_custom_logger
-
-
-def read_nodata_pixel_percentage(mtd_file):
-    """Read nodata pixel percentage from L2A product metadata file."""
-    tree = ET.parse(mtd_file)
-    root = tree.getroot()
-    quality_indicators_info = root.find(
-        "{https://psd-14.sentinel2.eo.esa.int/PSD/User_Product_Level-2A.xsd}Quality_Indicators_Info"
-    )
-    image_content_qi = quality_indicators_info.find("Image_Content_QI")
-    nodata_pixel_percentage = float(image_content_qi.find("NODATA_PIXEL_PERCENTAGE").text)
-    return nodata_pixel_percentage
-
-
-def read_nodata_from_l2a_prod(product_series, output_folder, products_api, logger):
-    """Read nodata pixels percentage in L2A product.
-    Input:
-        -product_series     pd.Series
-        -output_folder      Path
-        -products_api       SentinelProductsAPI
-        -logger             logging.Logger
-    Output:
-        -                   float or None
-    """
-
-    # download L2A product metadata file
-    nodefilter = make_path_filter("*MTD_MSIL2A.xml")
-    product_info = sentinelsat_retry_download(
-        products_api,
-        product_series["uuid"],
-        output_folder,
-        nodefilter,
-        logger,
-    )
-
-    if product_info is None:
-        return None
-    else:
-        # read metadata file to check nodata pixels percentage
-        l2a_safe_path = output_folder / product_series["filename"]
-        l2a_mtd_file = next(l2a_safe_path.rglob("*MTD_MSIL2A.xml"))
-        return read_nodata_pixel_percentage(l2a_mtd_file)
 
 
 def sentinelsat_retry_download(api, uuid, output_folder, nodefilter, logger):
@@ -132,7 +88,6 @@ def download_tci_image(config, output_folder=None, logger=None):
     copernicus_user = config.get("access", "copernicus_user")
     copernicus_password = config.get("access", "copernicus_password")
     aoi_file = Path(config.get("misc", "aoi_file_downloading"))
-    cleaning = config.get("misc", "cleaning")
     cloud_cover_max = config.get("search", "cloud_cover_max")
     timerange = config.get("search", "timerange")
 
@@ -179,7 +134,7 @@ def download_tci_image(config, output_folder=None, logger=None):
         logger.info("Querying Sentinel-2 products")
         products_df = api.to_dataframe(
             api.query(
-                MultiPoint(footprint_subset).wkt,
+                MultiPoint(footprint[:50]).wkt,  # arbitrarily query first 50 tiles
                 date=("NOW-{}DAY".format(timerange), "NOW"),
                 platformname="Sentinel-2",
                 producttype="S2MSI2A",
@@ -188,31 +143,15 @@ def download_tci_image(config, output_folder=None, logger=None):
             )
         )
 
-        # select a product that is fully covered (no nodata pixels)
-        logger.info("Selecting a product that is fully covered (no nodata pixels)")
-        for i, product_row in [
-            (i, p)
-            for (i, p) in products_df.iterrows()
-            if not p["title"] in downloaded_images["product"].to_list()
-        ]:
+        # filter out images that were already processed
+        products_df = products_df.loc[
+            ~products_df["title"].isin(downloaded_images["product"].to_list())
+        ]
 
-            logger.debug("Checking nodata for product: {}".format(product_row["title"]))
-
-            # check if product contains nodata pixels (which probably means it's on edge of swath)
-            nodata_pixel_percentage = read_nodata_from_l2a_prod(
-                product_row,
-                output_folder,
-                products_api,
-                logger,
-            )
-            if nodata_pixel_percentage != 0.0 or nodata_pixel_percentage is None:
-                logger.debug("Tile contains nodata or metadata download failure")
-                if cleaning:
-                    shutil.rmtree(output_folder / product_row["filename"])
-            else:
-                logger.info(f"Product {product_row['title']} is fully covered (0% nodata pixels)")
-                found_suitable_product = True
-                break
+        if len(products_df) > 0:
+            # arbitrarily select first product that satisfies criteria
+            product_row = products_df.iloc[0]
+            found_suitable_product = True
 
     if not found_suitable_product:  # case where while loop above didn't generate suitable product
         raise Exception("No suitable product found in any tile within the footprint")


### PR DESCRIPTION
S2coastalbot publishes subsets of S2 TCI images. A method was implemented to avoid including areas with nodata pixels in these subsets.

The method previously implemented consisted in filtering out S2 images that contained nodata pixels, prior to downloading and selecting a subset within the image. This method relied on downloading the metadata first, and reading the amount of nodata pixels from this metadata. Once a suitable image was downloaded, any subset along the coastline could be selected within this image.

The "node filter" capability provided by the sentinelsat library was required to download the metadata file only, but sentinelsat doesn't support the new CDSE. Also, many products were filtered out even though they contained only a small portion of nodata and could have provided a suitable scene, which sometimes resulted long processes.

This new method consists in downloading the TCI image, without any nodata-based filtering, then look for a subset of the image along the coastline that doesn't contain any nodata pixel. If no suitable subset is found, another image is downloaded, and so on until an image provided a suitable subset. This new method results in a quicker process, and removes the need for the "node filter" capability of sentinelsat, allowing to use another library supporting the new CDSE in the future.