### PR TITLE
Update mastodon login method

### DIFF
--- a/config/example_config.ini
+++ b/config/example_config.ini
@@ -10,11 +10,6 @@ twitter_consumer_secret =
 twitter_access_token =
 twitter_access_token_secret =
 
-mastodon_login_email =
-mastodon_password =
-mastodon_client_id =
-mastodon_client_secret =
-mastodon_base_url =
 mastodon_secret_file =
 
 [misc]

--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,13 @@ For example using pip:
 1. Install requirements: `pip install -r requirements.txt`
 2. Install project package in development mode: `pip install -e .`
 
+### Configuration
+
+To configure the bot, create a `config/config.ini` file in s2coastalbot's development folder, following the structure of `example_config.ini`.
+
+The `mastodon_secret_file` parameter should point a file containing the OAuth access token, which is required to log into the Mastodon API.
+This file can be generated using the instructions provided in [Mastodon.py's documentation](https://mastodonpy.readthedocs.io/en/stable/04_auth.html), and more precisely with the `to_file` argument of `Mastodon.log_in()`.
+
 ### TODO
 
 * [ ] Improve list of coastal tiles by using coastline vector file more precise than the [Natural Earth file](https://www.naturalearthdata.com/downloads/10m-physical-vectors/10m-coastline/)

--- a/s2coastalbot/main.py
+++ b/s2coastalbot/main.py
@@ -81,22 +81,8 @@ def s2coastalbot_main(config):
     try:
         # authenticate to Mastodon API
         logger.info("Authenticating to Mastodon API")
-        mastodon_email = config.get("access", "mastodon_login_email")
-        mastodon_password = config.get("access", "mastodon_password")
-        mastodon_client_id = config.get("access", "mastodon_client_id")
-        mastodon_client_secret = config.get("access", "mastodon_client_secret")
-        mastodon_base_url = config.get("access", "mastodon_base_url")
         mastodon_secret_file = config.get("access", "mastodon_secret_file")
-        mastodon = Mastodon(
-            client_id=mastodon_client_id,
-            client_secret=mastodon_client_secret,
-            api_base_url=mastodon_base_url,
-        )
-        mastodon.log_in(
-            mastodon_email,
-            mastodon_password,
-            to_file=mastodon_secret_file,
-        )
+        mastodon = Mastodon(access_token=mastodon_secret_file)
     except Exception as error_msg:
         logger.error(f"Error authenticating to Mastodon API: {error_msg}")
         if cleaning:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -64,11 +64,6 @@ def mock_config(mock_functions):
         "aoi_file_postprocessing": mock_functions["mock_aoi_file"],
     }
     config["access"] = {
-        "mastodon_login_email": "mock_mastodon_login_email",
-        "mastodon_password": "mock_mastodon_password",
-        "mastodon_client_id": "mock_mastodon_client_id",
-        "mastodon_client_secret": "mock_mastodon_client_secret",
-        "mastodon_base_url": "mock_mastodon_base_url",
         "mastodon_secret_file": "mock_mastodon_secret_file",
         "twitter_consumer_key": "mock_twitter_consumer_key",
         "twitter_consumer_secret": "mock_twitter_consumer_secret",
@@ -131,12 +126,7 @@ def test_mastodon_post(tmp_dir, mock_functions, mock_config):
 
     # Assert Mastodon API interaction
     # Cleaning is expected to be called when Twitter fails due to missing config
-    mock_mastodon.assert_called_once()
-    mock_mastodon_instance.log_in.assert_called_once_with(
-        "mock_mastodon_login_email",
-        "mock_mastodon_password",
-        to_file="mock_mastodon_secret_file",
-    )
+    mock_mastodon.assert_called_once_with(access_token="mock_mastodon_secret_file")
     mock_mastodon_instance.media_post.assert_called_once_with(
         media_file=mock_functions["mock_postprocessed_file"],
         description="Snapshot of a satellite image of a coastal area.",


### PR DESCRIPTION
Mastodon API has dropped password grant type. An OAuth access_token is now required. This adds an ad hoc manual step for the OAuth workflow, and simplifies the code slightly.

Configuration instructions are also added in the readme.