### PR TITLE
Improve download failure handling in sentinel2 module

### DIFF
--- a/s2coastalbot/sentinel2.py
+++ b/s2coastalbot/sentinel2.py
@@ -92,6 +92,7 @@ def download_tci_image(config, output_folder=None):
         if len(features) > 0:
             # arbitrarily select first product that satisfies criteria
             feature = features[0]
+            safe_path = output_folder / feature["properties"]["title"]
             found_suitable_product = True
 
     if not found_suitable_product:  # case where while loop above didn't generate suitable product
@@ -103,7 +104,7 @@ def download_tci_image(config, output_folder=None):
 
         feature_id = odata_download_with_nodefilter(
             feature["id"],
-            output_folder / feature["properties"]["title"],
+            safe_path,
             cdse_user,
             cdse_password,
             "*_TCI_10m.jp2",
@@ -113,9 +114,9 @@ def download_tci_image(config, output_folder=None):
 
     except Exception as error_msg:
         logger.error(f"Failed Sentinel-2 image download: {error_msg}")
-        if cleaning:
+        if cleaning and safe_path.exists():
             logger.info("Cleaning data")
-            shutil.rmtree(output_folder / feature["properties"]["title"])
+            shutil.rmtree(safe_path)
         raise Exception(error_msg)
 
     else:
@@ -128,7 +129,6 @@ def download_tci_image(config, output_folder=None):
         downloaded_images.to_csv(downloaded_images_file, index=False)
 
         # find tci file path
-        safe_path = output_folder / feature["properties"]["title"]
         tci_file_path = next(safe_path.rglob("*_TCI_10m.jp2"))
 
         return tci_file_path, datetime.datetime.fromisoformat(

--- a/tests/test_sentinel2.py
+++ b/tests/test_sentinel2.py
@@ -146,7 +146,7 @@ def test_failed_tci_image_download(mock_config, tmp_dir, mock_footprint_df, mock
     ), mock.patch(
         "s2coastalbot.sentinel2.odata_download_with_nodefilter", mock_odata_download
     ):
-        with pytest.raises(Exception, match="Failed Sentinel-2 image download"):
+        with pytest.raises(Exception, match="Feature ID is None after download"):
             download_tci_image(mock_config)
 
 

--- a/tests/test_sentinel2.py
+++ b/tests/test_sentinel2.py
@@ -39,7 +39,10 @@ def mock_config(tmp_dir):
     """Fixture to create a mock config."""
     config = configparser.ConfigParser()
     config["access"] = {"cdse_user": "mock_user", "cdse_password": "mock_password"}
-    config["misc"] = {"aoi_file_downloading": str(tmp_dir / "mock_aoi_file.geojson")}
+    config["misc"] = {
+        "aoi_file_downloading": str(tmp_dir / "mock_aoi_file.geojson"),
+        "cleaning": True,
+    }
     config["search"] = {"cloud_cover_max": "30", "timerange": "10"}
     return config
 


### PR DESCRIPTION
Add try/except block to handle failures in download from CDSE, cleanup the download folder and raise an exception. The exception will end the current iteration of the while loop in main.py, and thus retry calling `download_tci_image`.