### PR TITLE
Check mean pixels value to avoid blank images

### DIFF
--- a/s2coastalbot/postprocessing.py
+++ b/s2coastalbot/postprocessing.py
@@ -129,12 +129,17 @@ def postprocess_tci_image(input_file, aoi_file):
             logger.debug("Reading subset of TCI image")
             array = in_dataset.read(window=window)
 
-            # look for nodata pixels, if there are none, select this subset and continue
+            # look for nodata pixels
             logger.debug("Checking nodata pixels ratio")
             nonzero_array = np.count_nonzero(array, axis=0)  # array of non-zero count along bands
             nodata_array = nonzero_array == 0  # array of bool with True for nodata pixels
             nodata_count = np.count_nonzero(nodata_array)  # amount of nodata pixels in array
-            if nodata_count == 0:
+
+            # check the subset mean pixel value to avoid blank images (white is 255 for uint8)
+            mean_pixel_value = np.mean(array)
+
+            # select this subset if it contains non-white pixels and if it doesn't contain nodata
+            if mean_pixel_value < 240 and nodata_count == 0:
                 logger.info(
                     "Selected subset center (lon, lat): {:.4f} - {:.4f}".format(
                         subset_center.x, subset_center.y

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -146,7 +146,25 @@ def test_postprocess_tci_image(mock_rasterio_open, mock_gpd_read_file):
     indirect=["mock_rasterio_open", "mock_gpd_read_file"],
 )
 def test_postprocess_tci_image_only_nodata(mock_rasterio_open, mock_gpd_read_file):
-    """Postprocessing "sad" test where image doesn't contains data and coastline outside bounds."""
+    """Postprocessing "sad" test where image doesn't contain data."""
+
+    with mock.patch("s2coastalbot.postprocessing.rasterio.open", mock_rasterio_open), mock.patch(
+        "s2coastalbot.postprocessing.gpd.read_file", mock_gpd_read_file
+    ):
+        output_file, center_coords = postprocess_tci_image(
+            Path("tmp/fake/path/input.tif"), Path("tmp/fake/path/aoi.geojson")
+        )
+        assert output_file is None
+        assert center_coords is None
+
+
+@pytest.mark.parametrize(
+    "mock_rasterio_open, mock_gpd_read_file",
+    [(255, True)],
+    indirect=["mock_rasterio_open", "mock_gpd_read_file"],
+)
+def test_postprocess_tci_blank_image(mock_rasterio_open, mock_gpd_read_file):
+    """Postprocessing "sad" test where image contains only white pixels."""
 
     with mock.patch("s2coastalbot.postprocessing.rasterio.open", mock_rasterio_open), mock.patch(
         "s2coastalbot.postprocessing.gpd.read_file", mock_gpd_read_file
@@ -164,7 +182,7 @@ def test_postprocess_tci_image_only_nodata(mock_rasterio_open, mock_gpd_read_fil
     indirect=["mock_rasterio_open", "mock_gpd_read_file"],
 )
 def test_postprocess_tci_image_no_intersection(mock_rasterio_open, mock_gpd_read_file):
-    """Postprocessing "sad" test where image contains data and coastline outside bounds."""
+    """Postprocessing "sad" test where coastline outside bounds."""
 
     with mock.patch("s2coastalbot.postprocessing.rasterio.open", mock_rasterio_open), mock.patch(
         "s2coastalbot.postprocessing.gpd.read_file", mock_gpd_read_file


### PR DESCRIPTION
It can happen that subsets containing only white or very bright pixels are selected, notably in extreme latitudes where clouds cover the ocean and snow covers the land. This new check discards subsets with very high mean pixels values, that correspond to blank images.